### PR TITLE
Don't expect magic byte in received addresses

### DIFF
--- a/src/airtouch2/protocol/at2plus/message_common.py
+++ b/src/airtouch2/protocol/at2plus/message_common.py
@@ -17,8 +17,8 @@ NON_DATA_LENGTH = 10
 class CommonMessageOffsets(IntEnum):
     # Header is 0x55 0x55
     HEADER = 0
-    # 0x80 0xb0 when sending, 0x80 0x80 for receiving
-    # Except extended message which is 0x90 0xb0 when sending and 0x90 0x90 when receiving
+    # 0x80 0xb0 when sending, 0x?? 0x80 for receiving
+    # Except extended message which is 0x90 0xb0 when sending and 0x?? 0x90 when receiving
     ADDRESS = 2
     # 'Can be any data' - response will match
     MESAGE_ID = 4
@@ -63,9 +63,7 @@ class Header(Serializable):
             if (b != HEADER_MAGIC):
                 raise ValueError("Message header magic is invalid")
         type = MessageType(header_bytes[CommonMessageOffsets.MESSAGE_TYPE])
-        if header_bytes[CommonMessageOffsets.ADDRESS] != ADDRESS_CONSTANT:
-            raise ValueError(
-                f"Unexpected address byte: expected {hex(ADDRESS_CONSTANT)}, got {hex(header_bytes[CommonMessageOffsets.ADDRESS])}")
+        # Ignore the first byte of the address, as it's undefined for received messages.
         address = Address(header_bytes[CommonMessageOffsets.ADDRESS+1])
         if type == MessageType.CONTROL_STATUS:
             if (address != Address.NORMAL):


### PR DESCRIPTION
Here's what I did:

* Ran `at2plus_test.py`, let it fetch initial status, and left it running.
* Launched that AirTouch2+ app on my phone, and used it to change the fan speed of my airtouch unit.

`at2plus_test.py` receives a status message and errors out:

```
Read payload of size 8: 55:55:9f:80:33:c0:00:12
ValueError: Unexpected address byte: expected 0xb0, got 0x9f
Failed reading header, trying again
Read payload of size 8: 23:00:00:00:00:0a:00:01
ValueError: Message header magic is invalid
```

There's several other 8-byte payloads that also, obviously, complain about invalid header magic. But put together they do look a lot like a valid AC status message (0x23).

The protocol documentation only says this about the address for received messages:

> When receiving from AirTouch, last byte of address will be 0x80 or 0x90 (for Extended message).

I'm getting the impression the controller only uses an address of `0xb0 0x80` when it's replying to the client that requested the status, and a different address otherwise (perhaps `0x9f` represents an automatic status message as a result of a status change?). The way I read the documentation though, the first byte of the address from the controller is undefined.

So this PR simply ignores the first byte of the address in received messages. Repeating the above test with this branch, after changing the fan speed the test script outputs this:

```
Read payload of size 8: 55:55:9f:80:35:c0:00:12
Read payload of size 18: 23:00:00:00:00:0a:00:01:10:12:50:c1:02:b2:00:00:80:00
Read payload of size 2: f0:bc
Handling status message

            id: 0
            power: 1
            mode: 1
            fan_speed: 2
            set_point: 18.0
            temperature: 19.0
            turbo: False
            bypass: False
            spill: False
            timer: True
            error: 0


        id: 0
        name: Daikin
        start_group: 0
        group_count: 4
        supported_modes: [<AcSetMode.AUTO: 0>, <AcSetMode.HEAT: 1>, <AcSetMode.DRY: 2>, <AcSetMode.FAN: 3>, <AcSetMode.COOL: 4>]
        supported_fan_speeds: [<AcFanSpeed.AUTO: 0>, <AcFanSpeed.LOW: 2>, <AcFanSpeed.MEDIUM: 3>, <AcFanSpeed.HIGH: 4>]
        setpoint_limits:
        cool:
        min: 16
        max: 16

        heat:
        min: 16
        max: 16



Updated AC 0 with value
            id: 0
            power: 1
            mode: 1
            fan_speed: 2
            set_point: 18.0
            temperature: 19.0
            turbo: False
            bypass: False
            spill: False
            timer: True
            error: 0

Finished handling status message
```

Worth noting that very shortly afterwards another status message is received by the test script, this time with an address of `0xb0 0x80`. Huh.

```
Read payload of size 8: 55:55:b0:80:28:c0:00:12
Read payload of size 18: 23:00:00:00:00:0a:00:01:10:12:50:c1:02:b2:00:00:80:00
Read payload of size 2: cf:59
```
