### PR TITLE
Swap repeat data length and repeat data count in command packets

### DIFF
--- a/src/airtouch2/protocol/at2plus/control_status_common.py
+++ b/src/airtouch2/protocol/at2plus/control_status_common.py
@@ -20,10 +20,10 @@ class ControlStatusOffsets(IntEnum):
     # 2nd byte empty
     # bytes 3-4 are 'normal data' length
     NORMAL_DATA_LENGTH = 2
-    # bytes 5-6 are number of repeated 'repeat data's
-    REPEAT_DATA_COUNT = 4
-    # bytes 7-8 are each 'repeat data' length
-    REPEAT_DATA_LENGTH = 6
+    # bytes 5-6 are each 'repeat data' length
+    REPEAT_DATA_LENGTH = 4
+    # bytes 7-8 are number of repeated 'repeat data's
+    REPEAT_DATA_COUNT = 6
     SUBDATA = 8
 
 
@@ -55,8 +55,8 @@ class SubDataLength(Serializable):
 
     def to_bytes(self) -> bytes:
         return self.normal.to_bytes(2, 'big') + \
-            self.repeat_count.to_bytes(2, 'big') + \
-            self.repeat_length.to_bytes(2, 'big')
+            self.repeat_length.to_bytes(2, 'big') + \
+            self.repeat_count.to_bytes(2, 'big')
 
 
 @dataclass


### PR DESCRIPTION
Attempting to send command messages using `at2plus_test.py` for me was failing. For example, trying to change the set point:

```
Enter: 'q' to quit
       'r' to request AC0 ability
       't' to toggle AC0
       's' to set AC0 temperature setpoint
       'f' to set AC0 fan speed
       'm' to set AC0 mode
s
Enter setpoint: 20
Sending AcControlMessage with data: 55:55:80:b0:01:c0:00:0c:22:00:00:00:00:01:00:04:f0:ff:40:64:84:97

Enter: 'q' to quit
       'r' to request AC0 ability
       't' to toggle AC0
       's' to set AC0 temperature setpoint
       'f' to set AC0 fan speed
       'm' to set AC0 mode
IncompleteReadError - partial bytes:
Connection lost, reconnecting
```

at which point the script would reconnect, fetch the status (which definitely did not include the new setpoint of 20) and continue as normal.

So I captured the traffic between the AirTouch 2+ app on my android phone and my controller. The AC control packet the app sent when changing the set point to 20° was:

```
55:55:80:b0:06:c0:00:0c:22:00:00:00:00:04:00:01:00:ff:40:64:b6:7f
```

The only functional difference is that the repeat count (0x00 0x01) and repeat length (0x00 0x04) have swapped places in the working command sent by the app. I then verified this by sending a group control message from my app (turning off zone 3). The group control packet sent by the app was:

```
55:55:80:b0:16:c0:00:0c:20:00:00:00:00:04:00:01:02:02:ff:00:2e:6a
```

Again, repeat count and repeat length are in the opposite order to what's described in the protocol documentation.

So, I believe the documentation is incorrect, and the repeat length should go before the repeat count. This PR swaps those around in both kinds of control messages by the library.

With this change, requests to change the set point using the `at2plus_test.py` script work:

```
Enter: 'q' to quit
       'r' to request AC0 ability
       't' to toggle AC0
       's' to set AC0 temperature setpoint
       'f' to set AC0 fan speed
       'm' to set AC0 mode
s
Enter setpoint: 20
Sending AcControlMessage with data: 55:55:80:b0:01:c0:00:0c:22:00:00:00:00:04:00:01:f0:ff:40:64:84:0e

Enter: 'q' to quit
       'r' to request AC0 ability
       't' to toggle AC0
       's' to set AC0 temperature setpoint
       'f' to set AC0 fan speed
       'm' to set AC0 mode
Read payload of size 8: 55:55:b0:80:01:c0:00:12
Read payload of size 18: 23:00:00:00:00:0a:00:01:10:12:64:c1:02:a8:00:00:80:00
Read payload of size 2: 9a:79
Handling status message

            id: 0
            power: 1
            mode: 1
            fan_speed: 2
            set_point: 20.0
            temperature: 18.0
            turbo: False
            bypass: False
            spill: False
            timer: True
            error: 0
```