### PR TITLE
At2Client: Make system name and touchpad temp available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# uv
+uv.lock
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/src/airtouch2/at2/At2Client.py
+++ b/src/airtouch2/at2/At2Client.py
@@ -16,11 +16,13 @@ class At2Client:
     aircons_by_id: dict[int, At2Aircon]
     groups_by_id: dict[int, At2Group]
     system_name: str
+    touchpad_temp: int
 
     def __init__(self, host: str, dump_responses: bool = False, task_creator: TaskCreator = asyncio.create_task):
         self.aircons_by_id = {}
         self.groups_by_id = {}
         self.system_name: str = "UNKNOWN"
+        self.touchpad_temp: int = 0
 
         self._client = NetClient(host, 8899, self._on_connect, self._handle_one_message, task_creator)
         self._dump_responses: bool = dump_responses
@@ -87,6 +89,11 @@ class At2Client:
             return
 
         _LOGGER.debug(f"SystemInfo: {system_info}")
+        
+        # System-wide
+        self.system_name = system_info.system_name
+        self.touchpad_temp = system_info.touchpad_temp
+        
         # ACs
         for id, ac_info in system_info.aircons_by_id.items():
             if id not in self.aircons_by_id:

--- a/test_programs/at2.py
+++ b/test_programs/at2.py
@@ -1,0 +1,16 @@
+from airtouch2.at2 import At2Client
+import asyncio 
+
+client = At2Client("192.168.0.100")
+
+
+async def main():
+    if not await client.connect():
+        print("Connection failure")
+        
+    client.run()
+    await client.wait_for_ac()
+    print(client.touchpad_temp)
+    
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Previously, the system name & touchpad temp were not being set during message handling for the client. 

I need this as "measured temp" on the At2Aircon actually reads 0 for my system, but the touchpad temp returns a usable value.
