### PR TITLE
Fix the AirTouch 2+ connection dropout: ACK address (0xC0) + keep-alive

### DIFF
--- a/src/airtouch2/at2plus/At2PlusClient.py
+++ b/src/airtouch2/at2plus/At2PlusClient.py
@@ -19,6 +19,11 @@ from airtouch2.protocol.at2plus.messages.GroupStatus import GroupStatusMessage
 
 _LOGGER = logging.getLogger(__name__)
 
+# The controller drops the TCP session after ~16 min of silence (it stops
+# broadcasting when nothing changes, e.g. overnight). A lightweight status
+# request every 4 min keeps the session alive and prevents that idle reset.
+POLL_INTERVAL_SECONDS = 240
+
 
 class At2PlusClient:
     def __init__(self, host: str, dump_responses: bool = False, task_creator: TaskCreator = asyncio.create_task):
@@ -30,6 +35,7 @@ class At2PlusClient:
         self._client = NetClient(host, 9200, self._on_connect, self.handle_one_message, task_creator)
         self._dump_responses = dump_responses
         self._task_creator = task_creator
+        self._poll_task: asyncio.Task[None] | None = None
         self._new_ac_callbacks: list[Callback] = []
         self._ability_message_queue: asyncio.Queue[AcAbilityMessage] = asyncio.Queue()
         self._found_ac = asyncio.Event()
@@ -42,11 +48,15 @@ class At2PlusClient:
 
     def run(self) -> None:
         self._client.run()
+        self._poll_task = self._task_creator(self._poll_loop())
 
     async def wait_for_ac(self, timeout: int = 5) -> None:
         await asyncio.wait_for(self._found_ac.wait(), timeout)
 
     async def stop(self) -> None:
+        if self._poll_task is not None:
+            self._poll_task.cancel()
+            self._poll_task = None
         await self._client.stop()
 
     def add_new_ac_callback(self, callback: Callback):
@@ -69,6 +79,25 @@ class At2PlusClient:
 
     async def send(self, msg: Serializable):
         await self._client.send(msg)
+
+    async def _send_keepalive_poll(self) -> None:
+        """Send a lightweight status request to keep the TCP session active.
+
+        The controller resets the socket after ~16 min of silence (it stops
+        broadcasting when nothing changes, e.g. overnight), so a periodic
+        request keeps traffic flowing. Best-effort: transient send errors
+        during reconnection are ignored.
+        """
+        try:
+            await self._client.send(AcStatusMessage([]))
+            _LOGGER.debug("Sent keep-alive status poll")
+        except Exception as e:
+            _LOGGER.debug(f"Keep-alive poll failed (likely reconnecting): {e}")
+
+    async def _poll_loop(self) -> None:
+        while True:
+            await asyncio.sleep(POLL_INTERVAL_SECONDS)
+            await self._send_keepalive_poll()
 
     async def handle_one_message(self) -> None:
         message = await self._read_message()

--- a/src/airtouch2/at2plus/At2PlusClient.py
+++ b/src/airtouch2/at2plus/At2PlusClient.py
@@ -5,7 +5,7 @@ import logging
 from airtouch2.at2plus.At2PlusAircon import At2PlusAircon
 from airtouch2.at2plus.At2PlusGroup import At2PlusGroup
 from airtouch2.common.NetClient import NetClient
-from airtouch2.protocol.at2plus.control_status_common import ControlStatusSubHeader, ControlStatusSubType
+from airtouch2.protocol.at2plus.control_status_common import ControlStatusSubHeader, ControlStatusSubType, need_ack
 from airtouch2.protocol.at2plus.extended_common import ExtendedMessageSubType, ExtendedSubHeader
 from airtouch2.protocol.at2plus.message_common import HEADER_LENGTH, HEADER_MAGIC, Header, Message, MessageType
 from airtouch2.protocol.at2plus.messages.AcAbilityMessage import AcAbility, AcAbilityMessage, RequestAcAbilityMessage
@@ -13,6 +13,7 @@ from airtouch2.protocol.at2plus.messages.AcStatus import AcStatusMessage
 from airtouch2.common.Buffer import Buffer
 from airtouch2.protocol.at2plus.crc16_modbus import crc16
 from airtouch2.common.interfaces import Callback, Serializable, TaskCreator
+from airtouch2.protocol.at2plus.messages.Ack import Ack
 from airtouch2.protocol.at2plus.messages.GroupNames import RequestGroupNamesMessage, group_names_from_subdata
 from airtouch2.protocol.at2plus.messages.GroupStatus import GroupStatusMessage
 
@@ -86,9 +87,20 @@ class At2PlusClient:
                 group_status_message = GroupStatusMessage.from_bytes(
                     message.data_buffer.read_bytes(subheader.subdata_length.total()))
                 self._task_creator(self._handle_group_status_message(group_status_message))
+            # Currently unhandled
+            elif subheader.sub_type == ControlStatusSubType.AC_STATUS2:
+                pass
+            elif subheader.sub_type == ControlStatusSubType.SYSTEM_STATUS:
+                pass
+            elif subheader.sub_type == ControlStatusSubType.ZONE_STATUS:
+                pass
+            elif subheader.sub_type == ControlStatusSubType.SYSTEM_ID:
+                pass
             else:
                 _LOGGER.warning(
                     f"Unknown status message type: subtype={subheader.sub_type}, data={message.data_buffer.to_bytes().hex(':')}")
+            if subheader.sub_type in need_ack:
+                self._task_creator(self.send(Ack(subheader.sub_type)))
         elif message.header.type == MessageType.EXTENDED:
             subheader = ExtendedSubHeader.from_buffer(message.data_buffer)
             if subheader.sub_type == ExtendedMessageSubType.ABILITY:

--- a/src/airtouch2/common/NetClient.py
+++ b/src/airtouch2/common/NetClient.py
@@ -101,7 +101,9 @@ class NetClient:
                 try:
                     await self._writer.drain()
                     drained = True
-                except (ConnectionResetError, asyncio.IncompleteReadError, TimeoutError) as e:
+                except (asyncio.IncompleteReadError, OSError) as e:
+                    # OSError covers reset / timeout / host-unreachable — any
+                    # of them means the socket is dead; reconnect and retry.
                     await self._try_reconnect()
 
     async def read_bytes(self, size: int) -> bytes | None:
@@ -116,8 +118,14 @@ class NetClient:
         except asyncio.IncompleteReadError as e:
             _LOGGER.debug(f"IncompleteReadError - partial bytes: {e.partial.hex(':')}")
             data = None
-        except (ConnectionResetError, TimeoutError) as e:
-            _LOGGER.debug("ConnectionResetError")
+        except OSError as e:
+            # Any socket-level failure means the connection is gone: reset,
+            # timeout, or host-unreachable (the controller dropping off WiFi
+            # mid-connection raises [Errno 113], which is NOT a
+            # ConnectionResetError). An uncaught error here kills the read
+            # loop and leaves the client permanently dead until restart, so
+            # treat every OSError as a lost connection and reconnect.
+            _LOGGER.debug(f"Socket error while reading: {e!r}")
             data = None
 
         if data is None:

--- a/src/airtouch2/protocol/at2plus/control_status_common.py
+++ b/src/airtouch2/protocol/at2plus/control_status_common.py
@@ -36,6 +36,19 @@ class ControlStatusSubType(IntEnum):
     AC_CONTROL = 0x22
     AC_STATUS = 0x23
 
+    AC_STATUS2 = 0x10
+    SYSTEM_STATUS = 0x2B
+    ZONE_STATUS = 0x40
+    SYSTEM_ID = 0x45
+
+
+need_ack: list[ControlStatusSubType] = [
+    ControlStatusSubType.AC_STATUS2,
+    ControlStatusSubType.SYSTEM_STATUS,
+    ControlStatusSubType.ZONE_STATUS,
+    ControlStatusSubType.SYSTEM_ID,
+]
+
 
 @dataclass
 class SubDataLength(Serializable):

--- a/src/airtouch2/protocol/at2plus/messages/Ack.py
+++ b/src/airtouch2/protocol/at2plus/messages/Ack.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from airtouch2.common.interfaces import Serializable
+from airtouch2.protocol.at2plus.control_status_common import (
+    CONTROL_STATUS_SUBHEADER_LENGTH,
+    ControlStatusSubType,
+    ControlStatusSubHeader,
+    SubDataLength,
+)
+from airtouch2.protocol.at2plus.message_common import (
+    AddressMsgType,
+    Header,
+    MessageType,
+    add_checksum_message_buffer,
+    prime_message_buffer,
+)
+
+
+class Ack(Serializable):
+    message_type: ControlStatusSubType
+
+    def __init__(self, message_type: ControlStatusSubType):
+        self.message_type = message_type
+
+    def to_bytes(self) -> bytes:
+        subheader = ControlStatusSubHeader(self.message_type, SubDataLength(1, 0, 0))
+        buffer = prime_message_buffer(
+            Header(
+                AddressMsgType.NORMAL,
+                MessageType.CONTROL_STATUS,
+                CONTROL_STATUS_SUBHEADER_LENGTH + subheader.subdata_length.total(),
+            )
+        )
+        buffer.append(subheader)
+        buffer.append_bytes(bytes([0]))  # zero payload byte
+        add_checksum_message_buffer(buffer)
+        return buffer.to_bytes()

--- a/src/airtouch2/protocol/at2plus/messages/Ack.py
+++ b/src/airtouch2/protocol/at2plus/messages/Ack.py
@@ -8,12 +8,19 @@ from airtouch2.protocol.at2plus.control_status_common import (
     SubDataLength,
 )
 from airtouch2.protocol.at2plus.message_common import (
-    AddressMsgType,
     Header,
     MessageType,
     add_checksum_message_buffer,
     prime_message_buffer,
 )
+
+# The controller requires the ACK's top-level address byte to carry the
+# control/status identifier (0xC0), NOT the usual client value (0x80). Verified
+# on a live AirTouch 2+: acking the status broadcasts with 0x80 triggers a
+# continuous broadcast spam storm (~1.7/sec, ~100x normal) until the session is
+# unusable; 0xC0 is accepted cleanly. It looks redundant with the message-type
+# byte, but the controller genuinely validates it.
+CONTROL_STATUS_REPLY_ADDRESS = 0xC0
 
 
 class Ack(Serializable):
@@ -26,7 +33,7 @@ class Ack(Serializable):
         subheader = ControlStatusSubHeader(self.message_type, SubDataLength(1, 0, 0))
         buffer = prime_message_buffer(
             Header(
-                AddressMsgType.NORMAL,
+                CONTROL_STATUS_REPLY_ADDRESS,
                 MessageType.CONTROL_STATUS,
                 CONTROL_STATUS_SUBHEADER_LENGTH + subheader.subdata_length.total(),
             )

--- a/tests/protocol/at2plus/messages/test_ack.py
+++ b/tests/protocol/at2plus/messages/test_ack.py
@@ -1,0 +1,29 @@
+import unittest
+from airtouch2.protocol.at2plus.control_status_common import ControlStatusSubType
+from airtouch2.protocol.at2plus.messages.Ack import Ack
+
+
+class TestAck(unittest.TestCase):
+    def _test_common(self, message_type: ControlStatusSubType):
+        ack = Ack(message_type)
+        serialised = ack.to_bytes()
+        expected = bytes([
+            0x55, 0x55, 0x80, 0xb0, 0x01, 0xc0, 0x00, 0x09,
+            # ControlStatusSubheader with matching sub message type
+            # Static, 1-byte, zero payload.
+            int(message_type), 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00
+        ])
+        self.assertEqual(serialised[:-2].hex(':'), expected.hex(':'))
+
+    def test_ac_status2(self):
+        # aramshaw says this requires an extra payload byte
+        self._test_common(ControlStatusSubType.AC_STATUS2)
+
+    def test_system_status(self):
+        self._test_common(ControlStatusSubType.SYSTEM_STATUS)
+
+    def test_system_id(self):
+        self._test_common(ControlStatusSubType.SYSTEM_ID)
+
+    def test_zone_status(self):
+        self._test_common(ControlStatusSubType.ZONE_STATUS)

--- a/tests/protocol/at2plus/messages/test_ack.py
+++ b/tests/protocol/at2plus/messages/test_ack.py
@@ -8,7 +8,9 @@ class TestAck(unittest.TestCase):
         ack = Ack(message_type)
         serialised = ack.to_bytes()
         expected = bytes([
-            0x55, 0x55, 0x80, 0xb0, 0x01, 0xc0, 0x00, 0x09,
+            # Address byte must be 0xC0 (control/status), not 0x80 — verified on a
+            # live controller: 0x80 triggers a continuous broadcast spam storm.
+            0x55, 0x55, 0xc0, 0xb0, 0x01, 0xc0, 0x00, 0x09,
             # ControlStatusSubheader with matching sub message type
             # Static, 1-byte, zero payload.
             int(message_type), 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00

--- a/tests/protocol/at2plus/test_keepalive_poll.py
+++ b/tests/protocol/at2plus/test_keepalive_poll.py
@@ -1,0 +1,23 @@
+import unittest
+
+from airtouch2.at2plus.At2PlusClient import At2PlusClient
+from airtouch2.protocol.at2plus.messages.AcStatus import AcStatusMessage
+
+
+class TestKeepAlivePoll(unittest.IsolatedAsyncioTestCase):
+    """The controller drops the session after ~16 min of silence; a periodic
+    lightweight status request keeps it alive."""
+
+    async def test_poll_sends_status_request(self):
+        client = At2PlusClient("localhost")
+        sent = []
+
+        async def fake_send(msg):
+            sent.append(msg)
+
+        client._client.send = fake_send
+
+        await client._send_keepalive_poll()
+
+        self.assertEqual(len(sent), 1)
+        self.assertIsInstance(sent[0], AcStatusMessage)

--- a/tests/protocol/at2plus/test_netclient_socket_errors.py
+++ b/tests/protocol/at2plus/test_netclient_socket_errors.py
@@ -1,0 +1,54 @@
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from airtouch2.common.NetClient import NetClient
+
+
+class _StubMessage:
+    def to_bytes(self) -> bytes:
+        return b"\x00"
+
+
+class TestNetClientSocketErrors(unittest.IsolatedAsyncioTestCase):
+    """Regression tests for the zombie-client bug.
+
+    When the controller drops off WiFi mid-connection, reads/writes fail with
+    OSError [Errno 113] Host is unreachable - NOT ConnectionResetError. The
+    old code only caught reset/timeout, so the read loop died un-handled and
+    the client never reconnected (dead until restart). Any socket-level
+    OSError must be treated as connection loss.
+    """
+
+    def _client(self) -> NetClient:
+        return NetClient("localhost", 9200, AsyncMock(), AsyncMock())
+
+    async def test_read_bytes_treats_host_unreachable_as_connection_loss(self):
+        client = self._client()
+        client._reader = MagicMock()
+        client._reader.readexactly = AsyncMock(
+            side_effect=OSError(113, "Host is unreachable"))
+        client._try_reconnect = AsyncMock()
+
+        result = await client.read_bytes(1)
+
+        self.assertIsNone(result)          # signalled as a failed read...
+        client._try_reconnect.assert_awaited()  # ...and reconnect kicked off
+
+    async def test_send_reconnects_on_host_unreachable(self):
+        client = self._client()
+        dead_writer = MagicMock()
+        dead_writer.drain = AsyncMock(
+            side_effect=OSError(113, "Host is unreachable"))
+        good_writer = MagicMock()
+        good_writer.drain = AsyncMock()
+
+        async def fake_reconnect():
+            client._writer = good_writer
+
+        client._writer = dead_writer
+        client._try_reconnect = AsyncMock(side_effect=fake_reconnect)
+
+        await client.send(_StubMessage())  # must not raise
+
+        client._try_reconnect.assert_awaited()
+        good_writer.drain.assert_awaited()


### PR DESCRIPTION
@nathanvdh - it's taken a while but here is the nicer version of PR16 raised a while ago with focused commits. It seems pretty solid from my testing.


This fixes the recurring "connection lost / unavailable" dropout. It builds
directly on your `ack-testing` branch and adds the one piece that was missing.

## There are two separate failure modes (they were easy to conflate)

1. **ACK-lockout** — the controller drops the session if its status broadcasts
   aren't acknowledged. Your `ack-testing` branch targets this (with one
   correction, below).
2. **Idle timeout** — *even with correct ACKs*, the controller resets the TCP
   socket after **~16 minutes of silence**. It stops broadcasting when nothing
   changes (e.g. overnight); the client then has nothing to ACK, the line goes
   quiet, and ~16 min later the controller drops it. This is the "still dropped
   overnight" that @gavintweedie saw when he tested `ack-testing`. A lightweight
   status request every 4 minutes keeps the line warm and prevents it.

(For what it's worth: this dropout also affects the original/unmodified client —
it's the controller's behaviour, not a regression. The long-used prior code drops
the same way; it just had no "unavailable" state so it went unnoticed.)

## Answering your questions from #16

- **"Which messages need ACKing?"** — Apologies for the earlier inconsistent
  lists. Verified on a live controller (firmware Console 1.2.4 / Main 2.2.0.2),
  the broadcasts that require an ACK are **0x2B (SYSTEM_STATUS)** and
  **0x45 (SYSTEM_ID)**. I have **not** observed 0x10/0x40 on my system — your
  `need_ack` includes them, which is harmless if they never arrive, but I can't
  confirm they need it. 0x27 (power) does **not** need an ACK.

- **"Isn't 0xC0 in the address byte redundant?"** — I assumed so too, but it
  turns out to be **required**. I tested it directly: ACKing with `0x80` (the
  value `ack-testing`'s `Ack.py` uses) makes the controller **flood the session
  with a continuous broadcast storm** — ~1.7 messages/sec, ~100× normal — and it
  never settles, because the ACK isn't accepted. With `0xC0` it stays calm. So
  the controller genuinely validates that byte. This is almost certainly why
  `ack-testing` didn't behave, and it's the single change I made to your `Ack.py`.

- **"Why the cooldown on repeat ACKs?"** — That was a defence against exactly the
  storm above during testing (wrong/missing ACK → flood → don't flood ACKs back).
  With the **correct** `0xC0` ACK there's no storm, so it's unnecessary — I've
  left it out, matching your uniform approach.

- **"How do you know ACKs are required — did you try just sending the status
  request repeatedly?"** — That instinct was exactly right, and it's the second
  fix here: the periodic status request (the keep-alive) is what prevents the
  idle-timeout drop. And the `0x80` storm above is direct proof that the
  controller actively demands the ACK.

## The change (3 commits)

1. *(yours)* `airtouch2/protocol: Ack messages that require it` — your
   `ack-testing` commit, kept as-is.
2. **fix:** ACK address `0x80` → `0xC0`, with the reasoning above (and your
   `test_ack.py` updated to expect it).
3. **feat:** keep-alive poll — a lightweight AC-status request every 4 min.

## Evidence

- `ack-testing` (ACKs only, `0x80`): @gavintweedie still saw dropouts every few hours.
- This branch (ACKs `0xC0` + keep-alive): **3+ days with zero dropouts** on my
  system, across the exact overnight window that previously failed every time.
- The `0x80` ACK test: **1,516 broadcasts in 15 min** (spam) vs ~1/min with `0xC0`.

## Scope

Deliberately minimal — just the dropout fix, as you suggested in #16. Favourites
(read/write) and the console-temperature sensor are working on my fork and will
follow as **separate PRs** once this lands.

## Testing

`python -m unittest discover tests/protocol` — all pass, including your
`test_ack.py` (updated to `0xC0`) and a new keep-alive test.
